### PR TITLE
Broken notice

### DIFF
--- a/exampleSite/content/documentation/playground/alert-panels.md
+++ b/exampleSite/content/documentation/playground/alert-panels.md
@@ -69,6 +69,10 @@ A notice disclaimer
 A notice disclaimer
 {{< /notice >}}
 
+{{< notice note >}}
+A notice with [link](https://www.google.com)
+{{< /notice >}}
+
 #### Cards
 
 See [Bootstrap cards](https://getbootstrap.com/docs/4.0/components/card/)

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,1 +1,1 @@
-<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>{{ .Inner }}</div>
+<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>{{ .Inner | markdownify }}</div>


### PR DESCRIPTION
Fix "link inside notice". This is appeared after switch to latest Hugo, which now treats symbols % and "<" differently